### PR TITLE
fixed issue: The length of the string exceeds the value set on the ma…

### DIFF
--- a/src/JQDT.MVC/JQDataTableAttribute.cs
+++ b/src/JQDT.MVC/JQDataTableAttribute.cs
@@ -215,7 +215,8 @@
             var jsonResult = new JsonResult
             {
                 JsonRequestBehavior = JsonRequestBehavior.AllowGet,
-                Data = resultModel
+                Data = resultModel,
+                MaxJsonLength = int.MaxValue
             };
 
             return jsonResult;


### PR DESCRIPTION
Fixed error for large dataTable. 

I'm getting error: "The length of the string exceeds the value set on the maxJsonLength property" for large data. 

The above error occurs in ASP.Net when AJAX calls are made using AJAX clients like jQuery AJAX or AngularJS and the length of the AJAX Response exceeds the default predefined limit of 2097152 characters or 4MB.